### PR TITLE
OCPCLOUD-2777: Add openshift/e2e-tests.sh

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Running e2e-tests.sh"
+
+unset GOFLAGS
+tmp="$(mktemp -d)"
+
+if [ "${PULL_BASE_REF}" == "master" ]; then
+  # the default branch for cluster-capi-operator is main.
+  CCAPIO_BASE_REF="main"
+else
+  CCAPIO_BASE_REF=$PULL_BASE_REF
+fi
+
+echo "cloning github.com/openshift/cluster-capi-operator at branch '$CCAPIO_BASE_REF'"
+git clone --single-branch --branch="$CCAPIO_BASE_REF" --depth=1 "https://github.com/openshift/cluster-capi-operator.git" "$tmp"
+
+echo "running cluster-capi-operator's: make e2e"
+exec make -C "$tmp" e2e


### PR DESCRIPTION
Add openshift/e2e-tests.sh to allow us running CAPI e2e tests from presubmits launched from this repository.

This follows: https://github.com/openshift/cluster-api-provider-aws/blob/master/openshift/e2e-tests.sh