### PR TITLE
OCPBUGS-44880: Fetch service instance id from spec of IBMPowerVSCluster object while setting provider id

### DIFF
--- a/cloud/scope/powervs_machine.go
+++ b/cloud/scope/powervs_machine.go
@@ -922,10 +922,16 @@ func (m *PowerVSMachineScope) GetZone() string {
 
 // GetServiceInstanceID returns the service instance id.
 func (m *PowerVSMachineScope) GetServiceInstanceID() string {
-	if m.IBMPowerVSCluster.Status.ServiceInstance == nil || m.IBMPowerVSCluster.Status.ServiceInstance.ID == nil {
-		return ""
+	if m.IBMPowerVSCluster.Status.ServiceInstance != nil && m.IBMPowerVSCluster.Status.ServiceInstance.ID != nil {
+		return *m.IBMPowerVSCluster.Status.ServiceInstance.ID
 	}
-	return *m.IBMPowerVSCluster.Status.ServiceInstance.ID
+	if m.IBMPowerVSCluster.Spec.ServiceInstanceID != "" {
+		return m.IBMPowerVSCluster.Spec.ServiceInstanceID
+	}
+	if m.IBMPowerVSCluster.Spec.ServiceInstance != nil && m.IBMPowerVSCluster.Spec.ServiceInstance.ID != nil {
+		return *m.IBMPowerVSCluster.Spec.ServiceInstance.ID
+	}
+	return ""
 }
 
 // SetProviderID will set the provider id for the machine.


### PR DESCRIPTION
**What this PR does / Why we need it:**

This PR addresses a scenario where the service instance ID is explicitly passed when using an external cloud-provider template, but it is not set under the status field of the IBMPowerVSCluster object. In such cases, the provider ID for the machine is incorrectly set to an empty string, which can lead to issues.

To resolve this, this PR updates the logic to retrieve the service instance ID from the spec field of the IBMPowerVSCluster object if it is not found under the status field. This ensures that the service instance ID is correctly populated, even when not set in the status.

**Release note:**

`Fetches the service instance ID from the spec field of the IBMPowerVSCluster object if it is not present under the status.
`