### PR TITLE
OCPCLOUD-3359: Add TLS substitutions

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -8217,6 +8217,8 @@ spec:
         - --insecure-diagnostics=${CAPIBM_INSECURE_DIAGNOSTICS:=false}
         - --service-endpoint=${SERVICE_ENDPOINT:=none}
         - --v=${LOGLEVEL:=0}
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
         command:
         - /manager
         env:

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -11,3 +11,16 @@ images:
 - name: gcr.io/k8s-staging-capi-ibmcloud/cluster-api-ibmcloud-controller
   newName: registry.ci.openshift.org/openshift
   newTag: ibmcloud-cluster-api-controllers
+
+# Add TLS configuration args (substituted by cluster-capi-operator revisiongenerator)
+patches:
+- target:
+    kind: Deployment
+    name: capi-ibmcloud-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=${TLS_MIN_VERSION}"
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-cipher-suites=${TLS_CIPHER_SUITES}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controller-manager now supports configurable TLS settings: administrators can specify the minimum TLS version and the cipher suites used by the controller-manager process. These options are exposed as configurable settings (environment-driven) so cluster operators can enforce stronger TLS policies or adjust compatibility for different environments, improving security and deployment flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->