### PR TITLE
NO-JIRA: manifests-gen: scope provider webhooks to capi namespace

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -8289,6 +8289,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervscluster
   failurePolicy: Fail
   name: mibmpowervscluster.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8310,6 +8313,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsclustertemplate
   failurePolicy: Fail
   name: mibmpowervsclustertemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8331,6 +8337,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsimage
   failurePolicy: Fail
   name: mibmpowervsimage.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8352,6 +8361,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachine
   failurePolicy: Fail
   name: mibmpowervsmachine.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8373,6 +8385,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachinetemplate
   failurePolicy: Fail
   name: mibmpowervsmachinetemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8394,6 +8409,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpccluster
   failurePolicy: Fail
   name: mibmvpccluster.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8415,6 +8433,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpcmachine
   failurePolicy: Fail
   name: mibmvpcmachine.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8436,6 +8457,9 @@ webhooks:
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpcmachinetemplate
   failurePolicy: Fail
   name: mibmvpcmachinetemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8467,6 +8491,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervscluster
   failurePolicy: Fail
   name: vibmpowervscluster.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8488,6 +8515,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsclustertemplate
   failurePolicy: Fail
   name: vibmpowervsclustertemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8509,6 +8539,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsimage
   failurePolicy: Fail
   name: vibmpowervsimage.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8530,6 +8563,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachine
   failurePolicy: Fail
   name: vibmpowervsmachine.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8551,6 +8587,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmpowervsmachinetemplate
   failurePolicy: Fail
   name: vibmpowervsmachinetemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8572,6 +8611,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpccluster
   failurePolicy: Fail
   name: vibmvpccluster.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8593,6 +8635,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpcmachine
   failurePolicy: Fail
   name: vibmvpcmachine.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io
@@ -8614,6 +8659,9 @@ webhooks:
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-ibmvpcmachinetemplate
   failurePolicy: Fail
   name: vibmvpcmachinetemplate.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: openshift-cluster-api
   rules:
   - apiGroups:
     - infrastructure.cluster.x-k8s.io

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -2,7 +2,7 @@ module tools
 
 go 1.25.0
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
 
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -95,8 +95,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80 h1:r0S/yoZAI0iWo1JvoIijaIgWGWf/izg4WiV7Wrtz16k=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c h1:brDtyXDZ8M/6KpJ9rsXQ3KKGawgN4TeiD4NpjFvu3V4=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c h1:mCbdsqRsXvIw22zy5c07zmFpaE/ng6ehx0Pq399UM3w=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
@@ -3,6 +3,31 @@ kind: Component
 
 namespace: openshift-cluster-api
 
+resources:
+  - webhook-namespace-selector.yaml
+
+# Scope all provider webhooks to the openshift-cluster-api namespace.
+# This prevents webhooks from intercepting requests in other namespaces,
+# which would fail on unsupported platforms where the webhook server is not running.
+replacements:
+  - source:
+      kind: ConfigMap
+      name: webhook-namespace-selector
+      fieldPath: data.namespace
+    targets:
+      - select:
+          kind: ValidatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+      - select:
+          kind: MutatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+
 patches:
 
 # Retain Secrets internally for reference tracking, but don't emit them
@@ -14,6 +39,7 @@ patches:
     metadata:
       name: __ignored__
       annotations:
+        # Marks this resource as local-only so kustomize excludes it from the final output.
         config.kubernetes.io/local-config: "true"
 
 # Set OpenShift pod annotations on all Deployments' pod templates.

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/webhook-namespace-selector.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/webhook-namespace-selector.yaml
@@ -1,0 +1,14 @@
+# This ConfigMap is a kustomize workaround: replacements need a concrete source resource
+# to read a value from, but there is no real resource that holds the target namespace.
+# This ConfigMap acts as that source, providing the namespace value to inject into webhook
+# namespaceSelector fields via the replacements defined in kustomization.yaml.
+# It is marked as local-config so kustomize never emits it in the final output.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: webhook-namespace-selector
+  annotations:
+    # Marks this resource as local-only so kustomize excludes it from the final output.
+    config.kubernetes.io/local-config: "true"
+data:
+  namespace: openshift-cluster-api

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/opencontainers/go-digest
 # github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80
 ## explicit; go 1.25.0
 github.com/openshift/api/config/v1
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260429150927-40757eb5602c
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
 ## explicit; go 1.25.0
 github.com/openshift/cluster-capi-operator/manifests-gen
 github.com/openshift/cluster-capi-operator/manifests-gen/providermetadata


### PR DESCRIPTION
Bumps `manifests-gen` to include webhook namespace scoping, which adds a `namespaceSelector` to all provider webhooks restricting them to the `openshift-cluster-api` namespace.

This prevents webhooks from intercepting requests in other namespaces, which would fail on unsupported platforms where the webhook server is not running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated cluster CAPI operator dependencies to the latest version
  * Enhanced webhook configuration with improved namespace isolation for IBM CAPI resources in OpenShift environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->